### PR TITLE
Simple fix preview text with big URL

### DIFF
--- a/components/request.html
+++ b/components/request.html
@@ -128,7 +128,7 @@
 </script>
 
 <style>
-	.CLASS .status { font-size: 12px; margin: 0; padding: 10px; }
+	.CLASS .status { font-size: 12px; margin: 0; padding: 10px; overflow-wrap: break-word; }
 	.CLASS .status span { padding: 2px 3px; border-radius: var(--radius); color: #FFF; }
 </style>
 


### PR DESCRIPTION
Evidence:
![image](https://user-images.githubusercontent.com/504327/137410530-54b12cb7-a5d0-4990-8233-2b7288f03258.png)
